### PR TITLE
Add note that Notable is no longer OSS

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@
 * [Athens](https://github.com/athensresearch/athens) - open-source and local-first alternative to Roam Research.
 * [Obsidian](https://obsidian.md/) - Free for personal use app, that works on top of a local folder of plain text Markdown files.
 * [Notable](https://notable.app/) - Free app for simple note taking.
+  * Notable is no longer Open Source as of Sep 28, 2019 (v1.8.4 / [7403a47](https://github.com/notable/notable/commit/7403a47f7602860d227268dda08e3b6f504fd30c))
 * [Joplin](https://joplinapp.org/) - Open source note taking app that supports synchronization and has Windows, Linux, Android, Cli builds. Supports import from Evernote.
 * [Zettlr](https://www.zettlr.com/) - Markdown Editor for the 21st century.
 * [Foam](https://foambubble.github.io/) - VSCode plugin inspired by Roam Research.


### PR DESCRIPTION
Found it a little misleading when I looked at Notable's git repo and didn't see any source 😞 

----

Re: [Contribution guide](https://github.com/tehtbl/awesome-note-taking/blob/master/contributing.md):

Are these supposed to be links? I'm not sure what's being ask of contributors here:
>    Make sure you take care of this
>    And this as well
>    And don't forget to check this
