### PR TITLE
Add Stik to Tauri section

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@
 ### Tauri
 
 * 📕 [Treedome](https://codeberg.org/solver-orgz/treedome) - Open-source and local-first, encrypted, note taking application organized in tree-like structures.
+* 📖 [Stik](https://github.com/0xMassi/stik_app) - Instant thought capture for macOS. Global hotkey summons a post-it note, type and close. Notes stored as plain markdown files.
 
 ### Web UI
 * 📖🤖🔁 [Joplin](https://joplinapp.org/) - Open source note taking app that supports synchronization and has Windows, Linux, Android, Cli builds. Supports import from Evernote.


### PR DESCRIPTION
## What is Stik?

[Stik](https://stik.ink) is an instant thought capture app for macOS. Press a global hotkey, a post-it note appears, type your thought, close it — done. Notes are stored as plain markdown files in `~/Documents/Stik/`.

- **Open source**: [github.com/0xMassi/stik_app](https://github.com/0xMassi/stik_app) (MIT license)
- **Free**: No account, no cloud, no subscription
- **Built with**: Tauri 2.0 (Rust + React)
- **Website**: [stik.ink](https://stik.ink)
- **Installable via**: `brew install --cask 0xmassi/stik/stik` or GitHub Releases

## Checklist

- [x] Searched for duplicates — Stik is not currently listed
- [x] Added to the Tauri subsection under Open Source
- [x] Used the plain text emoji (notes stored as markdown)
- [x] Description is concise