### PR TITLE
Add Inkwell to Tauri section

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@
 
 * 📕 [Treedome](https://codeberg.org/solver-orgz/treedome) - Open-source and local-first, encrypted, note taking application organized in tree-like structures.
 * 📖 [Stik](https://github.com/0xMassi/stik_app) - Instant thought capture for macOS. Global hotkey summons a post-it note, type and close. Notes stored as plain markdown files.
+* 📖 [Inkwell](https://github.com/4worlds4w-svg/inkwell) - Portable Markdown editor with split view, live preview, themes, templates, focus mode, typewriter mode, find & replace, and diff viewer.
 
 ### Web UI
 * 📖🤖🔁 [Joplin](https://joplinapp.org/) - Open source note taking app that supports synchronization and has Windows, Linux, Android, Cli builds. Supports import from Evernote.


### PR DESCRIPTION
Adds [Inkwell](https://github.com/4worlds4w-svg/inkwell) to the Tauri section.

- Portable Markdown editor built with Rust + Tauri v2
- Split view, live preview, themes, templates, focus mode, typewriter mode, find & replace, diff viewer
- Cross-platform: Windows, Linux, macOS
- Free to use; PDF/HTML export requires a one-time Pro license