### PR TITLE
Move Hyprnote → Char to Tauri section

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,6 @@
 - 📖 [Red Notebook](https://rednotebook.app/) - Open source native desktop journal using plain-text files.
 - 📖🤖 [GitJournal](https://github.com/GitJournal/GitJournal) - Open source markdown notes editor with integrated syncing with Git. Supports iOS, Android, Linux and MacOS (flutter).
 - [Fluster](https://fluster-one.vercel.app) - All in one note taking solution for modern students and academics. Powered by Rust with integrated AI.
-- [Hyprnote](https://github.com/fastrepl/hyprnote) - Local-first AI Notepad for Private Meetings.
 
 ### CLI
 
@@ -90,6 +89,7 @@
 
 ### Tauri
 
+* [Char](https://github.com/fastrepl/char) - Local-first AI notepad for meetings.
 * 📕 [Treedome](https://codeberg.org/solver-orgz/treedome) - Open-source and local-first, encrypted, note taking application organized in tree-like structures.
 * 📖 [Stik](https://github.com/0xMassi/stik_app) - Instant thought capture for macOS. Global hotkey summons a post-it note, type and close. Notes stored as plain markdown files.
 


### PR DESCRIPTION
Hyprnote has been renamed to **Char** ([fastrepl/char](https://github.com/fastrepl/char)) and is a Tauri app, not a native GUI app.

This PR moves it from the Native GUI section to the Tauri section with the updated name and repo link.

I'm one of the maintainers of Char.