### PR TITLE
Add Revu to Native GUI section

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@
 - 📖🤖 [GitJournal](https://github.com/GitJournal/GitJournal) - Open source markdown notes editor with integrated syncing with Git. Supports iOS, Android, Linux and MacOS (flutter).
 - [Fluster](https://fluster-one.vercel.app) - All in one note taking solution for modern students and academics. Powered by Rust with integrated AI.
 - [Hyprnote](https://github.com/fastrepl/hyprnote) - Local-first AI Notepad for Private Meetings.
+- 📕 [Revu](https://github.com/JuliusBrussee/revu-swift) - Local-first spaced repetition note-taking app for macOS with FSRS scheduling, Notion-inspired UI, Anki import, study guides, and exams. Built with SwiftUI.
 
 ### CLI
 


### PR DESCRIPTION
## Summary

- Adds [Revu](https://github.com/JuliusBrussee/revu-swift) to the **Native GUI** section
- Revu is a local-first spaced repetition note-taking app for macOS with FSRS scheduling, Notion-inspired UI, Anki import, study guides, and exams
- Built with SwiftUI, GPL-3.0 licensed
- Website: https://revu.cards