### PR TITLE
Add SwarmVault

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@
 * 📖 [Tangent Notes](https://www.tangentnotes.com/) - An open source, local-first markdown note taking application designed to let you write the way you think.
 * [Notable](https://notable.app/) - Free app for simple note taking based on VS Code Editor. _Important:_ Notable is no longer Open Source as of Sep 28, 2019 (v1.8.4 / [7403a47](https://github.com/notable/notable/commit/7403a47f7602860d227268dda08e3b6f504fd30c))
 * [Athens](https://github.com/athensresearch/athens) - Open-source and local-first alternative to Roam Research. _Important:_ Now abandoned by the author.
+* [SwarmVault](https://github.com/swarmclawai/swarmvault) - Local-first RAG knowledge base compiler. Persistent markdown wiki, knowledge graph, hybrid SQLite FTS + embeddings, contradiction detection, and built-in MCP server.
 
 ### Tauri
 


### PR DESCRIPTION
Adding SwarmVault to the Open Source > Electron section.

SwarmVault is a local-first knowledge base compiler that turns raw research into a persistent markdown wiki with a knowledge graph and hybrid search index. It ships as an Electron desktop app with Obsidian integration, so it fits alongside the other Electron-based knowledge tools in this section.

- SwarmVault: https://github.com/swarmclawai/swarmvault

License: MIT