### PR TITLE
Add Save to Proprietary

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,7 @@
 - ⚠️ [Polar](https://getpolarized.io/) - An integrated reading environment to build your knowledge base. Website unreachable; appears abandoned.
 - 📕🍎🔒🔁 [Reflect](https://reflect.app/) - Fast, AI-powered note-taking app with end-to-end encryption. Available on Mac, Windows, web, and iOS.
 - 📖🔁 [Roam](https://roamresearch.com/) - A note-taking tool for networked thought.
+- 📖 [Save](https://www.savemarkdown.co) - Chrome extension and macOS menu bar app that saves any webpage as clean Markdown to a local vault, with a built-in MCP server exposing the vault to Claude.
 - 📖🍎🤖🔁 [Simplenote](http://simplenote.com) - Available for iOS, Android, macOS, Windows, Linux, and the web. Supports Markdown.
 - 📕🍎🤖🔁 [Somnote](http://somcloud.com/about/somnote) - Record and save important information, ideas, and moments. Available for multiple platforms.
 - 🤖 [Squid](http://squidnotes.com) - Android app to take digital handwritten notes for class, work, or fun. Markup PDFs and sign documents.


### PR DESCRIPTION
Adds Save to the Proprietary section.

Save is a Chrome extension + macOS menu bar app that captures any webpage as clean Markdown into a local vault (fully Obsidian-compatible). Its built-in MCP server exposes the vault to Claude Desktop and Claude Code, so Claude reads from the user's saved notes before answering.

Website: https://www.savemarkdown.co
Repo: https://github.com/jswallez/save-markdown