### PR TITLE
Add 不拖 (Butuo) — minimalist iOS to-do app with local-only storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@
 
 ## Proprietary
 
+- 📖🍎🔒 [不拖 (Butuo)](https://apps.apple.com/app/id6761042128) - Minimalist to-do app for iPhone and iPad. No account, no server, no sync. Data stored locally only. Free.
 - 📖🍎 [Bear](https://bear.app/) - Beautiful, flexible writing app for notes and prose. Apple platforms only (Mac, iPhone, iPad). Sync via iCloud with Bear Pro.
 - 📕🍎🤖🔁 [Capacities](https://capacities.io/) - Object-based note-taking app for networked thinking. Available on macOS, Windows, Linux, web, iOS, and Android.
 - 📕🍎🤖🔁 [Craft](https://www.craft.do/) - Beautiful native document editor for Mac, iPad, iPhone, Android, and Windows with real-time collaboration.


### PR DESCRIPTION
## What is this app?

**不拖 (Butuo)** is a minimalist to-do app for iPhone and iPad.

### Why it belongs here
- 🍎 iOS native (iPhone + iPad)
- 🔒 **No account, no server, no sync** — all data stored locally on device
- 📖 Free, no ads, no in-app purchases
- Extremely minimal UI: write it down, cross it off. That is it.

This fits the list as a proprietary iOS note/task tool with strong local-privacy focus.

**App Store:** https://apps.apple.com/app/id6761042128