### PR TITLE
Add Burn 451 to Proprietary

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,7 @@
 ## Proprietary
 
 - 📖🍎 [Bear](https://bear.app/) - Beautiful, flexible writing app for notes and prose. Apple platforms only (Mac, iPhone, iPad). Sync via iCloud with Bear Pro.
+- 📕🍎🔁 [Burn 451](https://burn451.cloud/?ref=awesome-note-taking) - AI-native read-later and knowledge vault. A 24-hour timer on each saved article forces read-or-delete; kept articles become a permanent Vault accessible to Claude and other AI agents via a built-in MCP server.
 - 📕🍎🤖🔁 [Capacities](https://capacities.io/) - Object-based note-taking app for networked thinking. Available on macOS, Windows, Linux, web, iOS, and Android.
 - 📕🍎🤖🔁 [Craft](https://www.craft.do/) - Beautiful native document editor for Mac, iPad, iPhone, Android, and Windows with real-time collaboration.
 - 📕🍎🔁 [DEVONthink](https://www.devontechnologies.com/apps/devonthink) - macOS and iOS app for storing, organizing, and working on documents and notes.


### PR DESCRIPTION
Adding Burn 451 — an AI-native read-later + knowledge vault for note-takers and knowledge workers.

Brief: Save any article with a 24-hour timer that forces read-or-delete. Kept articles become a permanent Vault that AI agents (Claude, Cursor, Claude Code) can query in real time via a built-in MCP server. iOS app + Web + Chrome extension.

Checklist (per contributing.md):

- [x] Primarily for note-taking or knowledge management — it's a PKM-adjacent read-later and vault
- [x] Entry concise, 1-2 sentences, ends with a period
- [x] Link goes to the official site
- [x] Icons: 📕 (proprietary/database format — uses Supabase, not raw markdown files), 🍎 (iOS app confirmed), 🔁 (cloud sync via Supabase). No 🤖 (no Android yet), no 🔒 (E2EE not documented).
- [x] Placed in alphabetical order inside `## Proprietary` — between Bear and Capacities
- [x] Not a duplicate — searched README for "burn" and "451"
- [x] Actively maintained — iOS app + web app live, product updates shipped within the past week