### PR TITLE
Add qnote to Tauri section

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@
 
 - 📖🍎 [Char](https://github.com/fastrepl/char) - Open-source AI notepad for meetings with flexible AI stack and on-device storage. `GPL-3.0` `Tauri/Rust+TypeScript`
 - 📖 [Inkwell](https://github.com/4worlds4w-svg/inkwell) - Portable Markdown editor with split view, live preview, themes, templates, focus mode, and diff viewer. `Source-available` `Tauri/Rust`
+- 📖 [qnote](https://github.com/Omibranch/qnote) - Minimal frameless notepad for Linux with Markdown preview, real PDF export via Typst, OCR via Tesseract, and automatic version history. Available on AUR. `MIT` `Tauri/Rust+TypeScript`
 - 📖 [Stik](https://github.com/0xMassi/stik_app) - Instant thought capture for macOS. Global hotkey summons a post-it note, type and close. Notes stored as plain markdown files. `MIT` `Tauri/TypeScript+Rust`
 - 📕 [Treedome](https://codeberg.org/solver-orgz/treedome) - Open-source and local-first, encrypted note-taking application organized in tree-like structures. `AGPL-3.0` `Tauri/Rust`
 


### PR DESCRIPTION
**qnote** is a minimal frameless notepad for Linux built with Tauri 2 and Rust.

- Plain text / Markdown storage (📖)
- Live Markdown preview
- PDF export via Typst (real PDF, not HTML wrapper)
- OCR via Tesseract
- Automatic version history with deduplication
- Frameless window, dark/light theme
- MIT license
- Available on AUR

GitHub: https://github.com/Omibranch/qnote

A good fit for the Tauri section alongside other Tauri-based note-taking apps.