### PR TITLE
Add Binderus — local-first Markdown editor (Tauri+Rust, ~9 MB)

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@
 
 ### Tauri
 
+- 📖🍎🔒 [Binderus](https://github.com/binderus/binderus) - Local-first Markdown notes with Notion-style WYSIWYG editor, slash commands, plugin system, custom themes via drop-in CSS, and encrypted vaults via libSQL. Tauri-based, ~9 MB. `Source-available (MIT frontend, proprietary backend)` `Tauri/Rust+TypeScript`
 - 📖🍎 [Char](https://github.com/fastrepl/char) - Open-source AI notepad for meetings with flexible AI stack and on-device storage. `GPL-3.0` `Tauri/Rust+TypeScript`
 - 📖 [Inkwell](https://github.com/4worlds4w-svg/inkwell) - Portable Markdown editor with split view, live preview, themes, templates, focus mode, and diff viewer. `Source-available` `Tauri/Rust`
 - 📖 [Stik](https://github.com/0xMassi/stik_app) - Instant thought capture for macOS. Global hotkey summons a post-it note, type and close. Notes stored as plain markdown files. `MIT` `Tauri/TypeScript+Rust`


### PR DESCRIPTION
Adds [Binderus](https://github.com/binderus/binderus) to the list — a free,
local-first Markdown note-taking app with Notion-style WYSIWYG editing on
plain `.md` files. Tauri + Rust, ~9 MB installer, Windows/macOS/Linux.

Project links:
- Website: https://www.binderus.com
- Source: https://github.com/binderus/binderus
- Releases: https://www.binderus.com/download