### PR TITLE
Add ToutKit to Electron

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@
 - 📖 [SwarmVault](https://github.com/swarmclawai/swarmvault) - Local-first RAG knowledge base compiler with persistent markdown wiki, knowledge graph, hybrid SQLite FTS and embeddings, contradiction detection, and built-in MCP server. `MIT` `Node.js/TypeScript`
 - 📖 [Tangent Notes](https://www.tangentnotes.com/) - An open source, local-first markdown note taking application designed to let you write the way you think. `Apache-2.0` `Electron/TypeScript`
 - 📖🤖🔁 [TidGi](https://github.com/tiddly-gittly/TidGi-Desktop) - Customizable personal knowledge-base with git as backup manager and blogging platform, based on TiddlyWiki. `MPL-2.0` `Electron/TypeScript`
+- 📖 [ToutKit](https://github.com/toutkit/toutkit) - Local-first desktop notebook where each note is a self-contained folder of HTML, SQLite, and scripts; a built-in terminal lets AI CLIs (Claude Code, Codex, Gemini) write interactive HTML pages rendered inline instead of plain text. `AGPL-3.0` `Electron/JavaScript`
 - 📖 [Zettlr](https://www.zettlr.com/) - Markdown editor for academics and researchers. `GPL-3.0` `Electron/TypeScript`
 
 <p align="right"><a href="#contents">back to top</a></p>


### PR DESCRIPTION
Adds [**ToutKit**](https://github.com/toutkit/toutkit) to the **Electron** category.

ToutKit is a local-first desktop notebook where each note is a self-contained folder of HTML, SQLite, and scripts. A built-in terminal pairs the notebook with AI CLIs (Claude Code, Codex, Gemini), and an in-app webview renders whatever the AI writes inline — so a note can grow from a static page into a sortable table, dashboard, or research tool without leaving your filesystem.

### Checklist

- [x] Tool is primarily for note-taking / knowledge management
- [x] Description is concise and ends with a period
- [x] Link goes to the official GitHub repo
- [x] Icons are accurate (📖 — notes are stored as plain HTML files; no mobile, no built-in sync, no E2EE in current release)
- [x] License (`AGPL-3.0`) and tech stack (`Electron/JavaScript`) included
- [x] Added to the Electron category, alphabetically after TidGi and before Zettlr
- [x] Not a duplicate
- [x] Actively maintained (commits within the last week)