### PR TITLE
Add Qonspekt — browser tool: article to atomic notes via Claude AI

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@
 - 📖⚠️ [Neuron](https://neuron.zettel.page/) - Open-source app for managing plain-text notes in Zettelkasten style. Superseded by Emanote. `AGPL-3.0` `Haskell`
 - 📖🍎🤖🔒🔁 [Notesnook](https://github.com/streetwriters/notesnook) - Fully open source and end-to-end encrypted note-taking app available on all platforms. `GPL-3.0` `Web/TypeScript`
 - 📖 [Outline](https://github.com/outline/outline) - Fast, collaborative team knowledge base. Self-hosted or cloud. `BSL-1.1` `Web/TypeScript`
+- 📖 [Qonspekt](https://dertill123.github.io/qonspekt/) - Browser-based tool to convert any article into atomic Obsidian notes via Claude AI. BYOK, no backend, no account required. `MIT` `Web/JavaScript`
 - 📖 [SilverBullet](https://github.com/silverbulletmd/silverbullet) - Free, open-source self-hosted PWA for markdown notes. `MIT` `TypeScript/Go`
 - 📕 [Solo](https://github.com/johnSamilin/solo) - Minimalistic private note-taking app with focus on typography. `MIT` `Web/TypeScript`
 - 📖 [TiddlyWiki](https://github.com/TiddlyWiki/TiddlyWiki5) - A self-contained JavaScript wiki for the browser, Node.js, AWS Lambda, and more. `BSD-3-Clause` `Web/JavaScript`


### PR DESCRIPTION
**Qonspekt** is a browser-based tool that converts any article into atomic Obsidian-ready notes using Claude AI.

- No backend, no account — API key stays in browser localStorage, sent directly to Anthropic
- Generates 3–7 atomic notes with YAML frontmatter, tags, aliases, and wikilinks
- ZIP download, MIT licensed

Live: https://dertill123.github.io/qonspekt/
Repo: https://github.com/DerTill123/qonspekt