### PR TITLE
Add Kuku

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@
 
 - 📖🍎 [Char](https://github.com/fastrepl/char) - Open-source AI notepad for meetings with flexible AI stack and on-device storage. `GPL-3.0` `Tauri/Rust+TypeScript`
 - 📖 [Inkwell](https://github.com/4worlds4w-svg/inkwell) - Portable Markdown editor with split view, live preview, themes, templates, focus mode, and diff viewer. `Source-available` `Tauri/Rust`
+- 📖🔁 [Kuku](https://kuku.mom) - Open-source local-first Markdown workspace for macOS with AI-assisted edits, backlinks, graph navigation, and reviewable diffs. `MIT` `Tauri/Rust+TypeScript`
 - 📖 [Stik](https://github.com/0xMassi/stik_app) - Instant thought capture for macOS. Global hotkey summons a post-it note, type and close. Notes stored as plain markdown files. `MIT` `Tauri/TypeScript+Rust`
 - 📕 [Treedome](https://codeberg.org/solver-orgz/treedome) - Open-source and local-first, encrypted note-taking application organized in tree-like structures. `AGPL-3.0` `Tauri/Rust`
 


### PR DESCRIPTION
Adds Kuku to the Tauri section.

Kuku is an open-source local-first Markdown workspace for macOS with AI-assisted edits, backlinks, graph navigation, optional encrypted sync, and reviewable diffs. It stores notes as ordinary Markdown files and is licensed under MIT.

Project: https://kuku.mom
Source: https://github.com/kuku-mom/kuku