### PR TITLE
Update Save entry: renamed to Minibase

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@
 - ⚠️ [Polar](https://getpolarized.io/) - An integrated reading environment to build your knowledge base. Website unreachable; appears abandoned.
 - 📕🍎🔒🔁 [Reflect](https://reflect.app/) - Fast, AI-powered note-taking app with end-to-end encryption. Available on Mac, Windows, web, and iOS.
 - 📖🔁 [Roam](https://roamresearch.com/) - A note-taking tool for networked thought.
-- 📖 [Save](https://www.savemarkdown.co) - Chrome extension and macOS menu bar app that saves any webpage as clean Markdown to a local vault, with a built-in MCP server exposing the vault to Claude.
+- 📖 [Minibase](https://www.minibase.md) - Chrome and Firefox extension plus macOS menu bar app that saves any webpage as clean Markdown to a local vault, with a built-in MCP server exposing the vault to Claude. (formerly Save)
 - 📖🍎🤖🔁 [Simplenote](http://simplenote.com) - Available for iOS, Android, macOS, Windows, Linux, and the web. Supports Markdown.
 - 📕🍎🤖🔁 [Somnote](http://somcloud.com/about/somnote) - Record and save important information, ideas, and moments. Available for multiple platforms.
 - 🤖 [Squid](http://squidnotes.com) - Android app to take digital handwritten notes for class, work, or fun. Markup PDFs and sign documents.


### PR DESCRIPTION
Renames the "Save" entry to "Minibase" (the project was renamed) and updates the URL to its new home, www.minibase.md. Also notes it's now a Firefox extension too. The old link still redirects, so this just keeps the entry current.

🤖 Generated with [Claude Code](https://claude.com/claude-code)